### PR TITLE
fix: batch CI fixes for all platforms

### DIFF
--- a/.github/workflows/build-platform.yml
+++ b/.github/workflows/build-platform.yml
@@ -30,6 +30,11 @@ on:
         type: boolean
         default: false
         description: "Install Android NDK"
+      filament-host-artifact:
+        required: false
+        type: string
+        default: ""
+        description: "Artifact name with Filament host tools for cross-compile (e.g. linux-filament)"
 
 jobs:
   tier0:
@@ -37,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dep: [spirv-headers, anari-sdk, openxr-sdk, curl, rmlui, nlohmann-json, wasmtime, filament]
+        dep: [spirv-headers, anari-sdk, openxr-sdk, openssl, curl, rmlui, nlohmann-json, wasmtime, filament]
     steps:
       - uses: actions/checkout@v4
 
@@ -67,14 +72,30 @@ jobs:
         with:
           targets: ${{ inputs.rust-targets }}
 
+      - name: Download Filament host tools
+        if: matrix.dep == 'filament' && inputs.filament-host-artifact != '' && steps.cache.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.filament-host-artifact }}
+          path: filament-host
+
       - name: Build ${{ matrix.dep }}
         if: steps.cache.outputs.cache-hit != 'true'
         env:
           ANDROID_NDK_ROOT: ${{ steps.ndk.outputs.ndk-path || '' }}
         run: |
           CMAKE_ARGS="${{ inputs.cmake-args }}"
-          # Substitute $ANDROID_NDK_ROOT in cmake args
           CMAKE_ARGS="${CMAKE_ARGS//\$ANDROID_NDK_ROOT/$ANDROID_NDK_ROOT}"
+
+          # Cross-compile Filament: use host tools from native platform build
+          if [ "${{ matrix.dep }}" = "filament" ] && [ -d "filament-host" ]; then
+            HOST_TOOLS=$(find filament-host -name "ImportExecutables*.cmake" -print -quit 2>/dev/null)
+            if [ -n "$HOST_TOOLS" ]; then
+              CMAKE_ARGS="$CMAKE_ARGS -DIMPORT_EXECUTABLES=${{ github.workspace }}/$HOST_TOOLS"
+              echo "Using Filament host tools: $HOST_TOOLS"
+            fi
+          fi
+
           cmake -S . -B build -DLIBS_DIR=${{ github.workspace }}/libs-${{ inputs.platform }} $CMAKE_ARGS
           cmake --build build --target ${{ matrix.dep }} --parallel $(nproc 2>/dev/null || sysctl -n hw.ncpu)
 
@@ -128,11 +149,13 @@ jobs:
       - name: Arrange artifacts
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
+          mkdir -p libs-${{ inputs.platform }}
           cd libs-${{ inputs.platform }}
           for d in ${{ inputs.platform }}-*; do
             dep="${d#${{ inputs.platform }}-}"
             [ -d "$d" ] && [ ! -d "$dep" ] && mv "$d" "$dep"
           done
+          ls -1 || true
 
       - name: Build ${{ matrix.dep }}
         if: steps.cache.outputs.cache-hit != 'true'
@@ -193,11 +216,13 @@ jobs:
       - name: Arrange artifacts
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
+          mkdir -p libs-${{ inputs.platform }}
           cd libs-${{ inputs.platform }}
           for d in ${{ inputs.platform }}-*; do
             dep="${d#${{ inputs.platform }}-}"
             [ -d "$d" ] && [ ! -d "$dep" ] && mv "$d" "$dep"
           done
+          ls -1 || true
 
       - name: Build ${{ matrix.dep }}
         if: steps.cache.outputs.cache-hit != 'true'
@@ -244,11 +269,13 @@ jobs:
 
       - name: Arrange artifacts
         run: |
+          mkdir -p libs-${{ inputs.platform }}
           cd libs-${{ inputs.platform }}
           for d in ${{ inputs.platform }}-*; do
             dep="${d#${{ inputs.platform }}-}"
             [ -d "$d" ] && [ ! -d "$dep" ] && mv "$d" "$dep"
           done
+          ls -1 || true
 
       - name: Install Rust
         if: inputs.rust-targets != ''

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,15 +28,19 @@ jobs:
       cmake-args: "-DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0"
       rust-targets: "aarch64-apple-darwin"
 
+  # Android/iOS need Filament host tools from the native platform build
   ios:
+    needs: macos
     uses: ./.github/workflows/build-platform.yml
     with:
       platform: ios
       runs-on: macos-14
       cmake-args: "-DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0 -DWASMTIME_CARGO_TARGET=aarch64-apple-ios -DSNEEZE_ENABLE_XR=OFF"
       rust-targets: "aarch64-apple-ios"
+      filament-host-artifact: macos-filament
 
   android:
+    needs: linux
     uses: ./.github/workflows/build-platform.yml
     with:
       platform: android
@@ -44,3 +48,4 @@ jobs:
       cmake-args: "-DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_ROOT/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-26 -DWASMTIME_CARGO_TARGET=aarch64-linux-android -DSNEEZE_ENABLE_XR=ON"
       rust-targets: "aarch64-linux-android"
       setup-ndk: true
+      filament-host-artifact: linux-filament

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required (VERSION 3.20)
 file (STRINGS "${CMAKE_SOURCE_DIR}/VERSION" SNEEZE_VER)
-project (Sneeze-SuperBuild VERSION ${SNEEZE_VER} LANGUAGES NONE)
+project (Sneeze-SuperBuild VERSION ${SNEEZE_VER} LANGUAGES C CXX)
 
 include (ExternalProject)
 
@@ -40,13 +40,11 @@ endif ()
 
 set (CROSS_COMPILE_ARGS)
 
-# Always forward compiler selection — needed when using a non-default
-# compiler (e.g. clang on Linux via toolchain file) even for native builds.
-if (CMAKE_C_COMPILER)
-   list (APPEND CROSS_COMPILE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER})
-endif ()
-if (CMAKE_CXX_COMPILER)
-   list (APPEND CROSS_COMPILE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER})
+# Always forward toolchain file — it carries compiler, stdlib, linker flags.
+# Even for native builds (e.g. clang+libc++ on Linux), ExternalProject deps
+# need the same toolchain to avoid mixing compilers/stdlibs.
+if (CMAKE_TOOLCHAIN_FILE)
+   list (APPEND CROSS_COMPILE_ARGS -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
 endif ()
 
 # Forward cross-compilation flags only when actually cross-compiling.
@@ -54,20 +52,11 @@ endif ()
 # explicitly to sub-projects causes CMake to set CMAKE_CROSSCOMPILING=TRUE,
 # which breaks projects like Filament that have a cross-compile workflow.
 if (CMAKE_CROSSCOMPILING)
-   if (CMAKE_TOOLCHAIN_FILE)
-      list (APPEND CROSS_COMPILE_ARGS -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
-   endif ()
    if (CMAKE_SYSTEM_NAME)
       list (APPEND CROSS_COMPILE_ARGS -DCMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME})
    endif ()
    if (CMAKE_SYSTEM_PROCESSOR)
       list (APPEND CROSS_COMPILE_ARGS -DCMAKE_SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR})
-   endif ()
-   if (CMAKE_OSX_ARCHITECTURES)
-      list (APPEND CROSS_COMPILE_ARGS "-DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}")
-   endif ()
-   if (CMAKE_OSX_DEPLOYMENT_TARGET)
-      list (APPEND CROSS_COMPILE_ARGS -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
    endif ()
    if (CMAKE_OSX_SYSROOT)
       list (APPEND CROSS_COMPILE_ARGS -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT})
@@ -234,11 +223,54 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "iOS")
    # iOS: use Apple's Secure Transport
    set (CURL_SSL_ARGS -DCURL_USE_SECTRANSPORT=ON -DCURL_USE_OPENSSL=OFF -DCURL_USE_SCHANNEL=OFF)
 elseif (ANDROID)
-   # Android: OpenSSL (must be pre-built or built alongside)
+   # Android: cross-compile OpenSSL, then curl uses it
    set (CURL_SSL_ARGS -DCURL_USE_OPENSSL=ON -DCURL_USE_SCHANNEL=OFF)
 else ()
    # macOS, Linux
    set (CURL_SSL_ARGS -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON)
+endif ()
+
+# ---------------------------------------------------------------------------
+# OpenSSL (Android only — other platforms have system OpenSSL)
+# ---------------------------------------------------------------------------
+
+set (CURL_EXTRA_DEPENDS)
+
+if (ANDROID)
+   # OpenSSL's build system is Configure (Perl), not CMake.
+   # Use ExternalProject with custom configure/build/install commands.
+   set (OPENSSL_INSTALL_DIR "${LIBS_DIR}/openssl/install")
+
+   ExternalProject_Add (openssl
+      GIT_REPOSITORY   https://github.com/openssl/openssl.git
+      GIT_TAG          openssl-3.3.1
+      GIT_SHALLOW      ON
+      SOURCE_DIR       "${LIBS_DIR}/openssl/src"
+      BINARY_DIR       "${LIBS_DIR}/openssl/src"
+      INSTALL_DIR      "${OPENSSL_INSTALL_DIR}"
+      CONFIGURE_COMMAND
+         ${CMAKE_COMMAND} -E env
+            "ANDROID_NDK_ROOT=${CMAKE_ANDROID_NDK}"
+            "PATH=${CMAKE_ANDROID_NDK}/toolchains/llvm/prebuilt/linux-x86_64/bin:$ENV{PATH}"
+         perl <SOURCE_DIR>/Configure
+            android-arm64
+            -D__ANDROID_API__=26
+            --prefix=<INSTALL_DIR>
+            --openssldir=<INSTALL_DIR>/ssl
+            no-shared no-tests no-ui-console
+      BUILD_COMMAND     make -j$ENV{NPROC}
+      INSTALL_COMMAND   make install_sw
+      BUILD_IN_SOURCE   ON
+   )
+
+   # Tell curl where to find our cross-compiled OpenSSL
+   set (CURL_SSL_ARGS ${CURL_SSL_ARGS}
+      -DOPENSSL_ROOT_DIR=${OPENSSL_INSTALL_DIR}
+      -DOPENSSL_USE_STATIC_LIBS=TRUE
+   )
+   set (CURL_EXTRA_DEPENDS openssl)
+else ()
+   add_custom_target (openssl)
 endif ()
 
 ExternalProject_Add (curl
@@ -255,6 +287,7 @@ ExternalProject_Add (curl
       -DBUILD_CURL_EXE=OFF
       ${CURL_SSL_ARGS}
       ${CROSS_COMPILE_ARGS}
+   DEPENDS ${CURL_EXTRA_DEPENDS}
 )
 
 # ---------------------------------------------------------------------------
@@ -467,9 +500,13 @@ if (WASMTIME_CARGO_TARGET MATCHES "aarch64-linux-android")
       file (WRITE "${CMAKE_BINARY_DIR}/wasmtime-cargo-config.toml"
          "[target.aarch64-linux-android]\nlinker = \"${_android_linker}\"\n"
       )
+      # cc crate also needs CC for C compilation in build scripts (e.g. zstd-sys)
+      set (_ndk_ar "${CMAKE_ANDROID_NDK}/toolchains/llvm/prebuilt/${_ndk_host}/bin/llvm-ar")
       set (WASMTIME_BUILD_ENV
          ${CMAKE_COMMAND} -E env
             "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=${_android_linker}"
+            "CC_aarch64-linux-android=${_android_linker}"
+            "AR_aarch64-linux-android=${_ndk_ar}"
       )
    else ()
       message (WARNING "Android NDK clang not found — Wasmtime cross-compile may fail")

--- a/cmake/toolchain-aarch64-linux.cmake
+++ b/cmake/toolchain-aarch64-linux.cmake
@@ -10,8 +10,10 @@
 set (CMAKE_SYSTEM_NAME    Linux)
 set (CMAKE_SYSTEM_PROCESSOR aarch64)
 
-set (CMAKE_C_COMPILER   clang)
-set (CMAKE_CXX_COMPILER clang++)
+find_program (_clang   NAMES clang-14 clang)
+find_program (_clangpp NAMES clang++-14 clang++)
+set (CMAKE_C_COMPILER   "${_clang}")
+set (CMAKE_CXX_COMPILER "${_clangpp}")
 
 set (CMAKE_C_COMPILER_TARGET   aarch64-linux-gnu)
 set (CMAKE_CXX_COMPILER_TARGET aarch64-linux-gnu)

--- a/cmake/toolchain-linux-clang.cmake
+++ b/cmake/toolchain-linux-clang.cmake
@@ -1,14 +1,21 @@
 # Native Linux x86_64 toolchain — clang + libc++
 # Same stdlib as macOS and Android NDK.
 #
-# Prerequisites (Ubuntu/Debian):
+# Prerequisites (Ubuntu 22.04+):
 #   sudo apt install clang lld libc++-dev libc++abi-dev
+# Prerequisites (Ubuntu 20.04):
+#   Install clang-14 from apt.llvm.org, then symlink or use versioned names.
 #
 # Usage:
 #   cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-linux-clang.cmake
 
-set (CMAKE_C_COMPILER   clang)
-set (CMAKE_CXX_COMPILER clang++)
+# Use versioned clang if available (apt.llvm.org on older distros), else bare name
+find_program (_clang   NAMES clang-14 clang)
+find_program (_clangpp NAMES clang++-14 clang++)
+find_program (_lld     NAMES lld-14 lld ld.lld-14 ld.lld)
+
+set (CMAKE_C_COMPILER   "${_clang}")
+set (CMAKE_CXX_COMPILER "${_clangpp}")
 
 set (CMAKE_CXX_FLAGS_INIT "-stdlib=libc++")
 set (CMAKE_EXE_LINKER_FLAGS_INIT "-stdlib=libc++ -fuse-ld=lld")


### PR DESCRIPTION
## Summary

- `LANGUAGES C CXX` → toolchain file properly processed, compilers forwarded
- Toolchains auto-find clang-14 for Ubuntu 20.04 compat
- Android: OpenSSL ExternalProject for curl SSL
- Android: CC/AR env vars for Wasmtime cargo `cc` crate
- CI: Filament host tools artifact for Android/iOS cross-compile
- CI: mkdir -p before arrange step (fixes glslang cd failure)
- CI: openssl added to tier0, android/ios `needs:` linux/macos
- Halogen: FindFilament lib/ fallback (pushed to master separately)

## Depends on
- MetaversalCorp/Halogen@master (FindFilament fix)