### PR TITLE
ci: slim per-dep artifacts to install/ (~90% size reduction)

### DIFF
--- a/.github/workflows/build-platform.yml
+++ b/.github/workflows/build-platform.yml
@@ -138,7 +138,15 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.platform }}-${{ matrix.dep }}
-          path: libs-${{ inputs.platform }}
+          # Ship only install/ content + filament's host tools from build/
+          # (matc/cmgen/resgen and ImportExecutables-Release.cmake — needed
+          # for cross-compile filament builds). src/ and the rest of build/
+          # are 10x the useful bytes and never consumed downstream; their
+          # inclusion was the root cause of disk-full errors in Artemis CI.
+          path: |
+            libs-${{ inputs.platform }}/**/install/**
+            libs-${{ inputs.platform }}/filament/build/tools/**
+            libs-${{ inputs.platform }}/filament/build/ImportExecutables-*.cmake
           retention-days: 3
 
   tier1:
@@ -221,7 +229,15 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.platform }}-${{ matrix.dep }}
-          path: libs-${{ inputs.platform }}
+          # Ship only install/ content + filament's host tools from build/
+          # (matc/cmgen/resgen and ImportExecutables-Release.cmake — needed
+          # for cross-compile filament builds). src/ and the rest of build/
+          # are 10x the useful bytes and never consumed downstream; their
+          # inclusion was the root cause of disk-full errors in Artemis CI.
+          path: |
+            libs-${{ inputs.platform }}/**/install/**
+            libs-${{ inputs.platform }}/filament/build/tools/**
+            libs-${{ inputs.platform }}/filament/build/ImportExecutables-*.cmake
           retention-days: 3
 
   tier2:
@@ -275,7 +291,15 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.platform }}-${{ matrix.dep }}
-          path: libs-${{ inputs.platform }}
+          # Ship only install/ content + filament's host tools from build/
+          # (matc/cmgen/resgen and ImportExecutables-Release.cmake — needed
+          # for cross-compile filament builds). src/ and the rest of build/
+          # are 10x the useful bytes and never consumed downstream; their
+          # inclusion was the root cause of disk-full errors in Artemis CI.
+          path: |
+            libs-${{ inputs.platform }}/**/install/**
+            libs-${{ inputs.platform }}/filament/build/tools/**
+            libs-${{ inputs.platform }}/filament/build/ImportExecutables-*.cmake
           retention-days: 3
 
   sneeze:


### PR DESCRIPTION
## Summary

- Each dep artifact was carrying full src/ + build/ dirs (wasmtime alone ~400MB of Rust source & target). Downstream consumers (Sneeze tier1/tier2/sneeze + Artemis platform jobs) only read install/ + filament's host tools from build/.
- Switch upload path to an include-list that keeps install/ trees and the filament host-tool bits.
- Expected outcomes: ~90% smaller artifacts; faster downloads in every downstream job; eliminates the disk-full failures that have been hitting Artemis Android/Quest builds.

## Test plan

- [ ] Full Sneeze CI stays green on all 4 platforms
- [ ] Artemis CI picks up the new run and still finds all the install/ paths and filament matc/ImportExecutables
- [ ] Artifact sizes visibly smaller vs prior run