### PR TITLE
deps(boringssl): find nasm in common Windows install paths

### DIFF
--- a/deps/boringssl.cmake
+++ b/deps/boringssl.cmake
@@ -13,6 +13,25 @@ if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
    list (APPEND BORINGSSL_EXTRA_ARGS -DOPENSSL_NO_ASM=1)
 endif ()
 
+# Windows: BoringSSL's CMakeLists does enable_language(ASM_NASM) without
+# probing common install paths, so nasm has to be on PATH or explicitly
+# passed. Winget's default NASM install drops nasm.exe under
+# %LOCALAPPDATA%/bin/NASM/, which is not on PATH out of the box. Look for
+# it in the usual places and forward the absolute path if found.
+if (WIN32 AND NOT CMAKE_CROSSCOMPILING)
+   find_program (NASM_EXECUTABLE nasm
+      HINTS
+         "$ENV{LOCALAPPDATA}/bin/NASM"
+         "$ENV{ProgramFiles}/NASM"
+         "$ENV{ProgramFiles\(x86\)}/NASM"
+   )
+   if (NASM_EXECUTABLE)
+      list (APPEND BORINGSSL_EXTRA_ARGS
+         -DCMAKE_ASM_NASM_COMPILER=${NASM_EXECUTABLE})
+      message (STATUS "BoringSSL: using NASM at ${NASM_EXECUTABLE}")
+   endif ()
+endif ()
+
 set (_repo "${SNEEZE_DEP_REPO}/boringssl")
 if (EXISTS "${_repo}/.git")
    set (_git_args)


### PR DESCRIPTION
BoringSSL's own CMakeLists calls \`enable_language(ASM_NASM)\` without probing known install locations, so nasm must be on PATH or passed via \`-DCMAKE_ASM_NASM_COMPILER\`. Winget's default NASM install drops \`nasm.exe\` under \`%LOCALAPPDATA%/bin/NASM/\`, which isn't on PATH out of the box — so a fresh \`winget install NASM.NASM\` followed by \`build-windows.ps1 -All\` produces:

> CMake Error at CMakeLists.txt:275 (enable_language):
>   No CMAKE_ASM_NASM_COMPILER could be found.

The README already lists NASM as a prerequisite, but the failure mode is confusing because the install itself succeeded.

Probe \`%LOCALAPPDATA%/bin/NASM\`, \`Program Files/NASM\`, and \`Program Files (x86)/NASM\` with \`find_program\` and forward the absolute path to BoringSSL's sub-build if found. PATH-installed NASM keeps working unchanged. No-op on non-Windows and on cross-compile (iOS forces \`OPENSSL_NO_ASM=1\`).

## Test plan
- [ ] Windows with NASM at \`%LOCALAPPDATA%/bin/NASM\` (winget default) + NASM not on PATH → boringssl builds
- [ ] Windows with NASM on PATH → still works (nothing regresses; the path is just resolved more explicitly)
- [ ] Linux / macOS CI unaffected (not WIN32)
- [ ] iOS unaffected (forces NO_ASM)