### PR TITLE
deps(boringssl): disable MACOSX_BUNDLE for iOS cross-compile

### DIFF
--- a/deps/boringssl.cmake
+++ b/deps/boringssl.cmake
@@ -11,6 +11,14 @@ set (BORINGSSL_INSTALL_DIR "${LIBS_DIR}/boringssl/install")
 set (BORINGSSL_EXTRA_ARGS)
 if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
    list (APPEND BORINGSSL_EXTRA_ARGS -DOPENSSL_NO_ASM=1)
+   # On iOS, CMake defaults MACOSX_BUNDLE=ON for every executable, but
+   # BoringSSL's install(TARGETS bssl ...) doesn't specify a BUNDLE
+   # DESTINATION, so configure dies with:
+   #   install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE
+   #   executable target "bssl".
+   # We don't ship bssl (Sneeze only needs libcrypto.a + libssl.a from
+   # the install), so disable bundle packaging for iOS sub-targets.
+   list (APPEND BORINGSSL_EXTRA_ARGS -DCMAKE_MACOSX_BUNDLE=OFF)
 endif ()
 
 # Windows: BoringSSL's CMakeLists does enable_language(ASM_NASM) without


### PR DESCRIPTION
iOS configure fails with:

> install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable target \"bssl\".

CMake defaults \`MACOSX_BUNDLE=ON\` for every executable when \`CMAKE_SYSTEM_NAME=iOS\`. BoringSSL's \`install(TARGETS bssl ...)\` doesn't set a BUNDLE DESTINATION, so configure aborts before anything builds.

Sneeze only consumes \`libcrypto.a\` + \`libssl.a\` from the install tree — \`bssl\` (the CLI) isn't shipped. Forcing \`CMAKE_MACOSX_BUNDLE=OFF\` in the iOS sub-build lets \`bssl\` install as a plain executable and unblocks configure.

One of three small cross-compile fixes coming as separate MRs after Dean's restructuring broke iOS/Android CI.

## Test plan
- [ ] iOS tier0 (boringssl) configures + builds
- [ ] Other platforms unchanged (the flag only applies inside the iOS branch)