### PR TITLE
deps: skip disabled deps gracefully in single-dep CI mode

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -194,7 +194,14 @@ endif ()
 if (DEP)
    list (FIND SNEEZE_DEPS "${DEP}" _dep_idx)
    if (_dep_idx LESS 0)
-      message (FATAL_ERROR "DEP '${DEP}' is not in the known deps list (${SNEEZE_DEPS})")
+      # Disabled for this platform (e.g. openxr-sdk on iOS) vs. typo.
+      # If the per-dep .cmake file exists, treat it as disabled -> no-op
+      # so CI can keep a uniform matrix without per-platform excludes.
+      if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${DEP}.cmake")
+         message (STATUS "DEP '${DEP}' is disabled for platform '${SNEEZE_PLATFORM}' (config '${SNEEZE_CONFIG}') -- skipping")
+         return ()
+      endif ()
+      message (FATAL_ERROR "DEP '${DEP}' is not a known Sneeze dep (enabled set: ${SNEEZE_DEPS})")
    endif ()
    include ("${CMAKE_CURRENT_SOURCE_DIR}/${DEP}.cmake")
 else ()


### PR DESCRIPTION
On iOS, \`SNEEZE_ENABLE_XR\` is forced off, so \`openxr-sdk\` is excluded from \`SNEEZE_DEPS\`. But CI still invokes \`-DDEP=openxr-sdk\` in its matrix and hit:

> CMake Error at CMakeLists.txt:197 (message):
>   DEP 'openxr-sdk' is not in the known deps list

Distinguish \"disabled for this platform\" (\`deps/<name>.cmake\` file exists but dep is absent from \`SNEEZE_DEPS\`) from \"unknown dep\" (typo, missing file). Skip the former with a STATUS message and \`return()\`; keep FATAL_ERROR for the latter. The CI matrix stays uniform across platforms without per-platform excludes, while typos in manual \`-DDEP=...\` invocations still fail loudly.

## Test plan
- [ ] iOS tier0 (openxr-sdk) now completes as a no-op (empty artifact)
- [ ] Other platforms' openxr-sdk still builds
- [ ] \`-DDEP=typo-here\` still fatal-errors