### PR TITLE
tests: gate XrTest on SNEEZE_ENABLE_XR, not just iOS

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,10 +47,12 @@ target_link_libraries (SpvTest PRIVATE
 )
 
 # ---------------------------------------------------------------------------
-# OpenXR test executable — iOS disables XR (no VR support on iOS)
+# OpenXR test executable — skipped when XR is disabled. iOS forces it off
+# (no VR support on iOS); consumers can also -DSNEEZE_ENABLE_XR=OFF on
+# other platforms (e.g. plain Android APK without OpenXR loader).
 # ---------------------------------------------------------------------------
 
-if (NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+if (SNEEZE_ENABLE_XR)
    add_executable (XrTest XrRuntimeTest.cpp)
 
    target_include_directories (XrTest PRIVATE ${OPENXR_INCLUDE})


### PR DESCRIPTION
When consumers pass \`-DSNEEZE_ENABLE_XR=OFF\` on non-iOS platforms (e.g. Android APK without the OpenXR loader), \`XrTest\` was still being compiled and failed at:

> fatal error: 'openxr/openxr.h' file not found

Gate on the actual feature flag instead of the platform. Caught locally during an Android APK build where \`-DSNEEZE_ENABLE_XR=OFF\` is needed.