### PR TITLE
fix(renderer): force Vulkan backend on Android

### DIFF
--- a/src/renderer/AnariRenderer.cpp
+++ b/src/renderer/AnariRenderer.cpp
@@ -127,6 +127,18 @@ bool ANARI_RENDERER::Initialize (int nWidth, int nHeight)
    m_nHeight = nHeight;
    m_aPixels.resize (nWidth * nHeight, 0);
 
+#if defined(__ANDROID__)
+   // Filament's DEFAULT backend on Android is OpenGL, whose engine init panics
+   // unless a JavaVM* was captured via JNI_OnLoad. Halogen's .so is dlopen'd by
+   // the ANARI runtime (not Java's System.loadLibrary), so JNI_OnLoad never
+   // fires. Force Vulkan: it uses VK_KHR_android_surface on a raw
+   // ANativeWindow* (supplied via HALOGEN_NATIVE_SURFACE below) — no JNI.
+   // Halogen reads FILAMENT_BACKEND in its initDevice(); the equivalent
+   // anariSetParameter("backend","vulkan") path is bypassed because Halogen
+   // doesn't promote staged params before reading them.
+   setenv ("FILAMENT_BACKEND", "vulkan", 0);
+#endif
+
    bool bOk = false;
 
    std::string sLibraryArg = m_sLibrary;

--- a/src/renderer/AnariRenderer.cpp
+++ b/src/renderer/AnariRenderer.cpp
@@ -190,7 +190,12 @@ bool ANARI_RENDERER::Initialize (int nWidth, int nHeight)
             ANARIObject ns = anariNewObject (m_pDevice, "nativeSurface", "default");
             if (ns)
             {
-               anariSetParameter (m_pDevice, ns, "nativeWindow", ANARI_VOID_POINTER, &m_pNativeWindow);
+               // ANARI_VOID_POINTER takes the pointer value directly as the
+               // 5th arg to anariSetParameter — NOT a pointer to it. The
+               // C++ wrapper at anari_cpp_impl.hpp:530 dereferences one level
+               // for this type; passing &m_pNativeWindow stores the wrong
+               // value and crashes inside vkCreateAndroidSurfaceKHR on Vulkan.
+               anariSetParameter (m_pDevice, ns, "nativeWindow", ANARI_VOID_POINTER, m_pNativeWindow);
                anariCommitParameters (m_pDevice, ns);
                m_pNativeSurface = reinterpret_cast<anari::api::Object*> (ns);
                m_bNativeSurface = true;


### PR DESCRIPTION
## Summary

Filament's DEFAULT backend on Android is OpenGL, whose engine init panics unless a `JavaVM*` was captured via `JNI_OnLoad`. Halogen's `.so` is `dlopen`'d by the ANARI runtime rather than loaded through Java's `System.loadLibrary`, so its `JNI_OnLoad` never fires and the JavaVM stays null — Filament `FEngine::loop` then aborts at `VirtualMachineEnv::getEnvironmentSlow` during EGL driver creation.

Force Vulkan instead: `VK_KHR_android_surface` takes a raw `ANativeWindow*` (supplied via our `HALOGEN_NATIVE_SURFACE` extension), no JNI involved.

Halogen reads `FILAMENT_BACKEND` inside its `initDevice()`, so `setenv("FILAMENT_BACKEND", "vulkan", 0)` in `ANARI_RENDERER::Initialize()` is the reliable path — the equivalent `anariSetParameter(device, "backend", "vulkan")` mechanism is bypassed because Halogen doesn't promote staged params before reading them.

No effect on desktop: Filament's `DEFAULT` already picks Vulkan there.

## Test plan

- [ ] Android APK still reaches `FEngine resolved backend: Vulkan` in logcat (previous OpenGL panic resolved)
- [ ] Native Windows / Linux / macOS desktop runs unchanged (no code on those paths touched)
- [ ] iOS Metal backend unchanged (`setenv` guarded by `__ANDROID__`)