### PR TITLE
fix(linux): use BoringSSL for curl + add libssl to Sneeze link line

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -212,8 +212,9 @@ else ()
    # the outer SNEEZE_CONFIG.
    add_dependencies (halogen anari-sdk filament)
 
-   # curl's Android branch links BoringSSL as its TLS/crypto backend.
-   if (ANDROID)
+   # curl links BoringSSL as its TLS/crypto backend on Linux + Android.
+   # macOS/iOS use SecTransport, Windows uses Schannel — neither needs BoringSSL.
+   if (NOT WIN32 AND NOT APPLE)
       add_dependencies (curl boringssl)
    endif ()
 endif ()

--- a/deps/curl.cmake
+++ b/deps/curl.cmake
@@ -3,14 +3,16 @@ if (WIN32)
 elseif (APPLE)
    # macOS + iOS: Apple's Secure Transport (no OpenSSL dep)
    set (CURL_SSL_ARGS -DCURL_USE_SECTRANSPORT=ON -DCURL_USE_OPENSSL=OFF -DCURL_USE_SCHANNEL=OFF)
-elseif (ANDROID)
-   # Android: curl links against BoringSSL (built by deps/boringssl.cmake).
+else ()
+   # Linux + Android: curl links against BoringSSL (built by deps/boringssl.cmake).
    # BoringSSL answers to the same FindOpenSSL interface as OpenSSL, so
    # CURL_USE_OPENSSL=ON still works -- we just point it at the BoringSSL
    # install tree. The Android NDK toolchain sets
    # CMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY which makes find_package(OpenSSL)
    # ignore OPENSSL_ROOT_DIR, so we also pass the explicit lib and include
-   # paths to short-circuit the search.
+   # paths to short-circuit the search. Using BoringSSL on Linux (instead
+   # of system OpenSSL) keeps the build hermetic per the no-apt-packages
+   # policy and matches what gets shipped to consumers.
    set (BORINGSSL_INSTALL_DIR "${LIBS_DIR}/boringssl/install")
    set (CURL_SSL_ARGS
       -DCURL_USE_OPENSSL=ON
@@ -21,9 +23,6 @@ elseif (ANDROID)
       -DOPENSSL_CRYPTO_LIBRARY=${BORINGSSL_INSTALL_DIR}/lib/libcrypto.a
       -DOPENSSL_SSL_LIBRARY=${BORINGSSL_INSTALL_DIR}/lib/libssl.a
    )
-else ()
-   # Linux
-   set (CURL_SSL_ARGS -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON)
 endif ()
 
 set (_repo "${SNEEZE_DEP_REPO}/curl")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -682,6 +682,7 @@ target_link_libraries (Sneeze PUBLIC
    ${CURL_LIB}
    ${RMLUI_CORE_LIB}
    ${RMLUI_DEBUGGER_LIB}
+   ${BORINGSSL_SSL_LIB}
    ${BORINGSSL_CRYPTO_LIB}
    vox::vox
 )


### PR DESCRIPTION
## Summary

Linux `libcurl.a` was being built against system OpenSSL (`CURL_USE_OPENSSL=ON` with implicit `OPENSSL_ROOT_DIR`), but the `linux / sneeze` CI link step only references `BORINGSSL_CRYPTO_LIB` and so fails with a wall of undefined `SSL_*` symbols (`SSL_CTX_check_private_key`, `SSL_new`, `SSL_free`, …).

## Fix

- **Linux now uses BoringSSL** as curl's TLS backend, mirroring Android. Keeps the build hermetic (no system `libssl-dev` dependency, matches the no-apt-packages policy) and matches what gets shipped to consumers.
- **Add `\${BORINGSSL_SSL_LIB}`** to the Sneeze link line so the curl-emitted `SSL_*` references resolve. No-op on Apple (SecTransport) / Windows (Schannel) — the static lib is just dropped on the floor when nothing references it.
- **Wire `curl→boringssl`** in the SuperBuild ordering for any non-Apple/non-Win target (for local-dev all-deps builds — CI builds each dep in isolation with all tier0 artifacts pre-fetched).

## Test plan

- [x] CI: `linux / sneeze` should now link cleanly.
- [x] Other platforms unchanged: Win uses Schannel, macOS/iOS use SecTransport, Android already used BoringSSL.

CI on `main` has been red since ~May 1 due to this; first commit to surface it landed when the curl OpenSSL backend stopped picking up the system libs at link time.