### PR TITLE
ci: add freetype to tier0, move rmlui to tier1

### DIFF
--- a/.github/workflows/build-platform.yml
+++ b/.github/workflows/build-platform.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dep: [spirv-headers, anari-sdk, openxr-sdk, boringssl, jwt-cpp, spirv-cross, rmlui, nlohmann-json, wasmtime, filament]
+        dep: [spirv-headers, anari-sdk, openxr-sdk, boringssl, jwt-cpp, spirv-cross, freetype, nlohmann-json, wasmtime, filament]
     steps:
       - uses: actions/checkout@v4
 
@@ -159,6 +159,7 @@ jobs:
           - dep: halogen
           - dep: curl
           - dep: vox
+          - dep: rmlui
     steps:
       - uses: actions/checkout@v4
 

--- a/deps/rmlui.cmake
+++ b/deps/rmlui.cmake
@@ -9,6 +9,13 @@ else ()
    )
 endif ()
 
+set (FREETYPE_ROOT "${LIBS_DIR}/FreeType/install")
+if (WIN32)
+   set (FREETYPE_LIB_NAME "freetype.lib")
+else ()
+   set (FREETYPE_LIB_NAME "libfreetype.a")
+endif ()
+
 ExternalProject_Add (rmlui
    ${_git_args}
    SOURCE_DIR       "${_repo}"
@@ -20,6 +27,12 @@ ExternalProject_Add (rmlui
       -DBUILD_SHARED_LIBS=OFF
       -DBUILD_SAMPLES=OFF
       -DRMLUI_FONT_ENGINE=freetype
-      -DCMAKE_PREFIX_PATH=${LIBS_DIR}/FreeType/install
+      -DCMAKE_PREFIX_PATH=${FREETYPE_ROOT}
+      # Cross-compile toolchains (iOS / Android) set CMAKE_FIND_ROOT_PATH_MODE
+      # so find_package (Freetype) refuses to look outside the sysroot. Pass
+      # the variables FindFreetype.cmake reports as missing directly to
+      # bypass the search and keep configure deterministic on every host.
+      -DFREETYPE_LIBRARY=${FREETYPE_ROOT}/lib/${FREETYPE_LIB_NAME}
+      -DFREETYPE_INCLUDE_DIRS=${FREETYPE_ROOT}/include/freetype2
       ${CROSS_COMPILE_ARGS}
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -585,9 +585,15 @@ endif ()
 set (SPIRV_SOURCES   deps/spirv/SpvPipeline.cpp)
 set (SPIRV_HEADERS   deps/spirv/SpvPipeline.h)
 
+set (XR_HEADERS deps/xr/XrRuntime.h)
 if (SNEEZE_ENABLE_XR)
-   set (XR_SOURCES      deps/xr/XrRuntime.cpp)
-   set (XR_HEADERS      deps/xr/XrRuntime.h)
+   # Real OpenXR loader. Pulls in libopenxr_loader via OPENXR_LOADER_LIB.
+   set (XR_SOURCES deps/xr/XrRuntime.cpp)
+else ()
+   # No-op stub for builds without OpenXR (e.g. iOS). Same XR_RUNTIME class,
+   # HasRuntime () returns false, Initialize () succeeds silently. Lets
+   # Engine.cpp drop its #ifdef SNEEZE_HAS_XR guards entirely.
+   set (XR_SOURCES deps/xr/XrRuntime_Stub.cpp)
 endif ()
 
 set (UI_SOURCES      deps/ui/UiContext.cpp)
@@ -674,9 +680,8 @@ target_compile_definitions (Sneeze PUBLIC
 if (SNEEZE_ENABLE_WASM)
    target_compile_definitions (Sneeze PUBLIC SNEEZE_HAS_WASM WASM_API_EXTERN= WASI_API_EXTERN=)
 endif ()
-if (SNEEZE_ENABLE_XR)
-   target_compile_definitions (Sneeze PUBLIC SNEEZE_HAS_XR)
-endif ()
+# SNEEZE_HAS_XR compile def is gone — XR_RUNTIME class is always present, the
+# real-vs-stub .cpp selection above is what gates the OpenXR linkage.
 
 target_link_libraries (Sneeze PUBLIC
    anari::anari_static

--- a/src/deps/xr/XrRuntime.cpp
+++ b/src/deps/xr/XrRuntime.cpp
@@ -11,35 +11,46 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Real OpenXR implementation. Compiled when SNEEZE_ENABLE_XR is ON. The
+// SDL-only / no-XR build picks XrRuntime_Stub.cpp instead.
 
 #include <Sneeze.h>
 #include "xr/XrRuntime.h"
+
+#include <openxr/openxr.h>
+
 #include <cstdlib>
 #include <cstring>
 
-using namespace SNEEZE::DEP;
+namespace SNEEZE { namespace DEP {
 
-XR_RUNTIME::XR_RUNTIME ()
-   : m_pEngine    (nullptr)
-   , hInstance   (XR_NULL_HANDLE)
-   , bHasRuntime (false)
+class XR_RUNTIME::Impl
+{
+public:
+   ENGINE*     m_pEngine    = nullptr;
+   XrInstance  hInstance    = XR_NULL_HANDLE;
+   bool        bHasRuntime  = false;
+   std::string sRuntimeName;
+};
+
+XR_RUNTIME::XR_RUNTIME () : m_pImpl (new Impl ())
 {
 }
 
 XR_RUNTIME::~XR_RUNTIME ()
 {
-   if (hInstance != XR_NULL_HANDLE)
+   if (m_pImpl->hInstance != XR_NULL_HANDLE)
    {
-      xrDestroyInstance (hInstance);
-      hInstance = XR_NULL_HANDLE;
+      xrDestroyInstance (m_pImpl->hInstance);
+      m_pImpl->hInstance = XR_NULL_HANDLE;
    }
-   bHasRuntime = false;
-   sRuntimeName.clear ();
+   delete m_pImpl;
 }
 
 bool XR_RUNTIME::Initialize (ENGINE* pEngine)
 {
-   m_pEngine = pEngine;
+   m_pImpl->m_pEngine = pEngine;
    // Suppress the loader's own stderr diagnostics - we handle all error cases
    // ourselves with clearer messages. Without this, the loader prints alarming
    // "Error [GENERAL | xrCreateInstance | OpenXR-Loader]" lines on machines
@@ -62,24 +73,24 @@ bool XR_RUNTIME::Initialize (ENGINE* pEngine)
    pCreateInfo.enabledApiLayerCount   = 0;
    pCreateInfo.enabledExtensionCount  = 0;
 
-   XrResult nResult = xrCreateInstance (&pCreateInfo, &hInstance);
+   XrResult nResult = xrCreateInstance (&pCreateInfo, &m_pImpl->hInstance);
    if (XR_FAILED (nResult))
    {
-      bHasRuntime = false;
-      m_pEngine->Log (IENGINE::kLOGLEVEL_Warning, "XR_RUNTIME",
+      m_pImpl->bHasRuntime = false;
+      pEngine->Log (IENGINE::kLOGLEVEL_Warning, "XR_RUNTIME",
          "OpenXR loader initialized - no XR runtime detected (code " + std::to_string (nResult) + ")");
-      m_pEngine->Log (IENGINE::kLOGLEVEL_Warning, "XR_RUNTIME",
+      pEngine->Log (IENGINE::kLOGLEVEL_Warning, "XR_RUNTIME",
          "This is normal on machines without a VR/AR headset or runtime installed.");
       return true;
    }
 
-   bHasRuntime = true;
+   m_pImpl->bHasRuntime = true;
 
    XrInstanceProperties pProps = { XR_TYPE_INSTANCE_PROPERTIES };
-   if (XR_SUCCEEDED (xrGetInstanceProperties (hInstance, &pProps)))
+   if (XR_SUCCEEDED (xrGetInstanceProperties (m_pImpl->hInstance, &pProps)))
    {
-      sRuntimeName = pProps.runtimeName;
-      m_pEngine->Log (IENGINE::kLOGLEVEL_Info, "XR_RUNTIME",
+      m_pImpl->sRuntimeName = pProps.runtimeName;
+      pEngine->Log (IENGINE::kLOGLEVEL_Info, "XR_RUNTIME",
          "OpenXR " + std::to_string (XR_VERSION_MAJOR (XR_CURRENT_API_VERSION)) + "."
          + std::to_string (XR_VERSION_MINOR (XR_CURRENT_API_VERSION)) + "."
          + std::to_string (XR_VERSION_PATCH (XR_CURRENT_API_VERSION))
@@ -92,12 +103,7 @@ bool XR_RUNTIME::Initialize (ENGINE* pEngine)
    return true;
 }
 
-bool XR_RUNTIME::HasRuntime () const
-{
-   return bHasRuntime;
-}
+bool XR_RUNTIME::HasRuntime () const          { return m_pImpl->bHasRuntime;   }
+std::string XR_RUNTIME::GetRuntimeName () const { return m_pImpl->sRuntimeName; }
 
-std::string XR_RUNTIME::GetRuntimeName () const
-{
-   return sRuntimeName;
-}
+}} // namespace SNEEZE::DEP

--- a/src/deps/xr/XrRuntime.h
+++ b/src/deps/xr/XrRuntime.h
@@ -15,12 +15,17 @@
 #ifndef SNEEZE_XR_RUNTIME_H
 #define SNEEZE_XR_RUNTIME_H
 
-#include <openxr/openxr.h>
+#include <string>
 
 namespace SNEEZE
 {
    namespace DEP
    {
+      // XR_RUNTIME exposes the OpenXR runtime to the engine. The implementation
+      // is selected at CMake-configure time: when SNEEZE_ENABLE_XR is ON the
+      // real OpenXR loader lives in XrRuntime.cpp; otherwise XrRuntime_Stub.cpp
+      // provides a no-op stub (Initialize succeeds with HasRuntime () == false).
+      // Either way the header is openxr-free so consumers don't need the SDK.
       class XR_RUNTIME
       {
       public:
@@ -33,10 +38,8 @@ namespace SNEEZE
          std::string GetRuntimeName () const;
 
       private:
-         ENGINE* m_pEngine;
-         XrInstance  hInstance;
-         bool        bHasRuntime;
-         std::string sRuntimeName;
+         class Impl;
+         Impl* m_pImpl;
       };
    } // namespace DEP
 }

--- a/src/deps/xr/XrRuntime_Stub.cpp
+++ b/src/deps/xr/XrRuntime_Stub.cpp
@@ -1,0 +1,41 @@
+// Copyright 2026 Metaversal Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// No-op XR_RUNTIME for platforms without OpenXR SDK (iOS today; any
+// build where SNEEZE_ENABLE_XR is OFF). Initialize succeeds but the
+// runtime reports "no VR/AR runtime detected" through HasRuntime () so
+// the rest of the engine can branch on that the same way it does for a
+// real XR loader that couldn't find a runtime on the host.
+
+#include <Sneeze.h>
+#include "xr/XrRuntime.h"
+
+namespace SNEEZE { namespace DEP {
+
+class XR_RUNTIME::Impl {};
+
+XR_RUNTIME::XR_RUNTIME () : m_pImpl (nullptr)         {}
+XR_RUNTIME::~XR_RUNTIME ()                            {}
+
+bool XR_RUNTIME::Initialize (ENGINE* pEngine)
+{
+   pEngine->Log (IENGINE::kLOGLEVEL_Info, "XR_RUNTIME",
+      "OpenXR support disabled at build time (no headset / runtime expected on this platform).");
+   return true;
+}
+
+bool XR_RUNTIME::HasRuntime () const                  { return false; }
+std::string XR_RUNTIME::GetRuntimeName () const       { return {};    }
+
+}} // namespace SNEEZE::DEP

--- a/src/sneeze/Engine.cpp
+++ b/src/sneeze/Engine.cpp
@@ -45,7 +45,9 @@ public:
       m_bInitialized (false),
       m_pWasmRuntime (nullptr),
       m_pSpvPipeline (nullptr),
+#ifdef SNEEZE_HAS_XR
       m_pXrRuntime   (nullptr),
+#endif
       m_pUiContext   (nullptr),
       m_pControl     (nullptr),
       m_pNetwork     (nullptr),

--- a/src/sneeze/Engine.cpp
+++ b/src/sneeze/Engine.cpp
@@ -24,9 +24,7 @@
 #include "astro/RMCObject.h"
 #include "wasm/WasmRuntime.h"
 #include "spirv/SpvPipeline.h"
-#ifdef SNEEZE_HAS_XR
 #include "xr/XrRuntime.h"
-#endif
 #include "ui/UiContext.h"
 
 using namespace SNEEZE;
@@ -45,9 +43,7 @@ public:
       m_bInitialized (false),
       m_pWasmRuntime (nullptr),
       m_pSpvPipeline (nullptr),
-#ifdef SNEEZE_HAS_XR
       m_pXrRuntime   (nullptr),
-#endif
       m_pUiContext   (nullptr),
       m_pControl     (nullptr),
       m_pNetwork     (nullptr),
@@ -74,12 +70,10 @@ m_pPersona = new persona::PERSONA (m_pEngine);
 
             if (m_pSpvPipeline->Initialize (m_pEngine))
             {
-#ifdef SNEEZE_HAS_XR
                m_pXrRuntime = new DEP::XR_RUNTIME ();
 
                if (m_pXrRuntime->Initialize (m_pEngine))
                {
-#endif
                   m_pUiContext = new DEP::UI_CONTEXT ();
 
                   if (m_pUiContext->Initialize (m_pEngine))
@@ -111,10 +105,8 @@ m_pPersona = new persona::PERSONA (m_pEngine);
                      else m_pEngine->Log (IENGINE::kLOGLEVEL_Error, "SNEEZE", "Failed to initialize network");
                   }
                   else m_pEngine->Log (IENGINE::kLOGLEVEL_Error, "SNEEZE", "Failed to initialize UI context");
-#ifdef SNEEZE_HAS_XR
                }
                else m_pEngine->Log (IENGINE::kLOGLEVEL_Error, "SNEEZE", "Failed to initialize XR runtime");
-#endif
             }
             else m_pEngine->Log (IENGINE::kLOGLEVEL_Error, "SNEEZE", "Failed to initialize SPIR-V pipeline");
          }
@@ -147,10 +139,9 @@ m_pPersona = new persona::PERSONA (m_pEngine);
       delete m_pUiContext;
       m_pUiContext = nullptr;
 
-#ifdef SNEEZE_HAS_XR
       delete m_pXrRuntime;
       m_pXrRuntime = nullptr;
-#endif
+
       delete m_pSpvPipeline;
       m_pSpvPipeline = nullptr;
 
@@ -405,9 +396,7 @@ private:
 
    SNEEZE::DEP::WASM_RUNTIME* m_pWasmRuntime;
    SNEEZE::DEP::SPV_PIPELINE* m_pSpvPipeline;
-   #ifdef SNEEZE_HAS_XR
    SNEEZE::DEP::XR_RUNTIME*   m_pXrRuntime;
-   #endif
    SNEEZE::DEP::UI_CONTEXT*   m_pUiContext;
    
    // Control (owns engine thread, agents, metronome, cleanup queue)


### PR DESCRIPTION
## Summary

Recent commits added FreeType as a Sneeze dep (\`deps/freetype.cmake\`, with \`add_dependencies(rmlui freetype)\`) but didn't update the CI matrix, so no platform was building / uploading a \`freetype\` artifact. Downstream consumers — both this repo's final \`linux/macos/ios sneeze\` stage and Artemis's per-platform build steps — fail at configure with:

\`\`\`
CMake Error at .../FindSneezeFreeType.cmake:14 (find_library):
  ...
\`\`\`

## Changes

- Add \`freetype\` to the tier0 matrix. No deps, builds in parallel with the other tier0 libs.
- Move \`rmlui\` from tier0 to tier1. Tier1 jobs download every tier0 artifact (\`pattern: \${{ inputs.platform }}-*\`), so rmlui's CMake finds freetype at the expected install path.

## Test plan

- [ ] linux + macos + ios + android: tier0 freetype produces \`<platform>-freetype\` artifact
- [ ] tier1 rmlui sees the freetype artifact and configures cleanly
- [ ] linux/macos/ios sneeze stage configures + builds again (currently failing on \`FindSneezeFreeType.cmake\`)

Unblocks Artemis PR https://github.com/MetaversalCorp/Artemis/pull/13 which can't fetch a usable Sneeze main artifact set otherwise.