### PR TITLE
fix(network): embed Mozilla CA bundle for libcurl on Android/Linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -557,6 +557,35 @@ set (NETWORK_SOURCES
    sneeze/network/Network.cpp)
 set (NETWORK_HEADERS)
 
+# Embed Mozilla's CA bundle (cacert.pem) as a string blob so libcurl can
+# verify HTTPS certificates on platforms whose system has no libcurl-
+# readable CA store (Android NDK + BoringSSL, in particular). Win32 uses
+# SChannel + the Windows store; Apple uses SecureTransport + Keychain;
+# both ignore CAINFO_BLOB, but compiling the symbol unconditionally
+# avoids a per-platform link surface.
+set (SNEEZE_CACERT_PEM "${CMAKE_CURRENT_BINARY_DIR}/cacert.pem")
+if (NOT EXISTS "${SNEEZE_CACERT_PEM}")
+   message (STATUS "Fetching cacert.pem from curl.se")
+   file (DOWNLOAD https://curl.se/ca/cacert.pem "${SNEEZE_CACERT_PEM}"
+         TIMEOUT 30
+         TLS_VERIFY ON
+         STATUS _cacert_status)
+   list (GET _cacert_status 0 _cacert_code)
+   if (NOT _cacert_code EQUAL 0)
+      file (REMOVE "${SNEEZE_CACERT_PEM}")
+      message (FATAL_ERROR "Failed to download cacert.pem: ${_cacert_status}")
+   endif ()
+endif ()
+file (READ "${SNEEZE_CACERT_PEM}" SNEEZE_CACERT_CONTENT)
+configure_file (
+   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cacert_data.cpp.in"
+   "${CMAKE_CURRENT_BINARY_DIR}/cacert_data.cpp"
+   @ONLY)
+# Kept out of NETWORK_SOURCES because that list also feeds source_group(TREE),
+# which requires every file to live under CMAKE_CURRENT_SOURCE_DIR. The
+# generated source is added directly to the Sneeze target below instead.
+set (NETWORK_GENERATED_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/cacert_data.cpp")
+
 set (CONTAINER_HEADERS)
 
 set (STORAGE_SOURCES  sneeze/storage/Storage.cpp sneeze/storage/Unit.cpp sneeze/storage/Silo.cpp)
@@ -642,6 +671,7 @@ add_library (Sneeze STATIC
    ${STB_SOURCES}       ${STB_HEADERS}
    ${INCLUDE_HEADERS}
    ${KERNEL_EMBED_FILES}
+   ${NETWORK_GENERATED_SOURCES}
 )
 add_dependencies (Sneeze CompileKernels)
 

--- a/src/cmake/cacert_data.cpp.in
+++ b/src/cmake/cacert_data.cpp.in
@@ -1,0 +1,17 @@
+// Auto-generated at configure time from Mozilla's NSS CA bundle.
+// Source: https://curl.se/ca/cacert.pem (fetched by src/CMakeLists.txt).
+//
+// Network.cpp passes this blob to libcurl via CURLOPT_CAINFO_BLOB so
+// HTTPS verification works on platforms where the system has no
+// libcurl-readable CA store (Android / Linux NDK builds, where curl
+// links against BoringSSL).
+
+namespace SNEEZE {
+   extern const char* const g_szCaCertPem;
+   extern const unsigned long g_nCaCertPemLen;
+}
+
+namespace SNEEZE {
+   const char* const g_szCaCertPem = R"SNZ_CACRT(@SNEEZE_CACERT_CONTENT@)SNZ_CACRT";
+   const unsigned long g_nCaCertPemLen = sizeof(R"SNZ_CACRT(@SNEEZE_CACERT_CONTENT@)SNZ_CACRT") - 1;
+}

--- a/src/sneeze/network/Network.cpp
+++ b/src/sneeze/network/Network.cpp
@@ -635,6 +635,19 @@ public:
                curl_easy_setopt (pCurl, CURLOPT_FOLLOWLOCATION, 1L);
                curl_easy_setopt (pCurl, CURLOPT_TIMEOUT, 300L);
 
+#if !defined(_WIN32) && !defined(__APPLE__)
+               // Android/Linux: BoringSSL has no default CA store; feed it
+               // Mozilla's bundle embedded at configure time. Win32 (SChannel)
+               // and Apple (SecureTransport) use their OS-managed stores.
+               extern const char*        const g_szCaCertPem;
+               extern const unsigned long       g_nCaCertPemLen;
+               curl_blob caBlob;
+               caBlob.data  = const_cast<void*> (static_cast<const void*> (g_szCaCertPem));
+               caBlob.len   = g_nCaCertPemLen;
+               caBlob.flags = CURL_BLOB_NOCOPY;
+               curl_easy_setopt (pCurl, CURLOPT_CAINFO_BLOB, &caBlob);
+#endif
+
                CURLcode nCode = curl_easy_perform (pCurl);
 
                out.close ();
@@ -645,7 +658,12 @@ public:
                if (m_bShuttingDown)
                   bResult = false;
                else if (nCode != CURLE_OK || nHttpCode < 200 || nHttpCode >= 300)
-                  m_pEngine->Log (IENGINE::kLOGLEVEL_Warning, "NETWORK", "Fetch failed for " + sUrl + " (HTTP " + std::to_string (nHttpCode) + ")");
+               {
+                  std::string sErr = "Fetch failed for " + sUrl + " (HTTP " + std::to_string (nHttpCode) + ")";
+                  if (nCode != CURLE_OK)
+                     sErr += " curl=" + std::to_string (nCode) + " (" + curl_easy_strerror (nCode) + ")";
+                  m_pEngine->Log (IENGINE::kLOGLEVEL_Warning, "NETWORK", sErr);
+               }
                else
                {
                   std::string sAlgo, sExpected, sActual;


### PR DESCRIPTION
## Summary
- curl built against BoringSSL (the Linux/Android Sneeze path) has no default CA store, so every HTTPS fetch from Artemis-on-Android fails before reaching the server (surfaced as `HTTP 0` in the NETWORK warning log).
- Configure-time pulls Mozilla's `cacert.pem` from `curl.se`, embeds it into a generated `cacert_data.cpp` via `configure_file`, and `Network.cpp` passes it to libcurl via `CURLOPT_CAINFO_BLOB` on non-Windows non-Apple builds (those two have their own OS-managed stores).
- Also surfaces the curl error code + `curl_easy_strerror` in the NETWORK warning so future fetch failures show the real cause instead of just `HTTP 0`.

## Test plan
- [ ] CI green across all platforms
- [ ] Artemis-on-Android can fetch celestial textures over HTTPS (previously every fetch returned `HTTP 0`)