### PR TITLE
fix(network): Latin-1 fallback for HTTP response headers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -553,9 +553,11 @@ set (SOM_HEADERS
 
 set (NETWORK_SOURCES
    sneeze/network/Asset.cpp
+   sneeze/network/Encoding.cpp
    sneeze/network/File.cpp
    sneeze/network/Network.cpp)
-set (NETWORK_HEADERS)
+set (NETWORK_HEADERS
+   sneeze/network/Encoding.h)
 
 # Embed Mozilla's CA bundle (cacert.pem) as a string blob so libcurl can
 # verify HTTPS certificates on platforms whose system has no libcurl-

--- a/src/sneeze/network/Encoding.cpp
+++ b/src/sneeze/network/Encoding.cpp
@@ -1,0 +1,58 @@
+// Copyright 2026 Metaversal Corporation. All rights reserved.
+
+#include "Encoding.h"
+
+namespace SNEEZE
+{
+
+static bool IsAscii (const std::string& sIn)
+{
+   for (unsigned char c : sIn)
+      if (c >= 0x80)
+         return false;
+   return true;
+}
+
+static bool IsValidUtf8 (const std::string& sIn)
+{
+   size_t i = 0;
+   while (i < sIn.size ())
+   {
+      unsigned char c = static_cast<unsigned char> (sIn[i]);
+      size_t n;
+      if      (c < 0x80)            { ++i; continue; }
+      else if ((c & 0xE0) == 0xC0)  n = 2;
+      else if ((c & 0xF0) == 0xE0)  n = 3;
+      else if ((c & 0xF8) == 0xF0)  n = 4;
+      else                          return false;
+
+      if (i + n > sIn.size ())
+         return false;
+      for (size_t k = 1; k < n; ++k)
+         if ((static_cast<unsigned char> (sIn[i + k]) & 0xC0) != 0x80)
+            return false;
+      i += n;
+   }
+   return true;
+}
+
+std::string ToUtf8 (const std::string& sIn)
+{
+   if (IsAscii (sIn) || IsValidUtf8 (sIn))
+      return sIn;
+
+   std::string sOut;
+   sOut.reserve (sIn.size () * 2);
+   for (unsigned char c : sIn)
+   {
+      if (c < 0x80) sOut.push_back (static_cast<char> (c));
+      else
+      {
+         sOut.push_back (static_cast<char> (0xC0 | (c >> 6)));
+         sOut.push_back (static_cast<char> (0x80 | (c & 0x3F)));
+      }
+   }
+   return sOut;
+}
+
+} // namespace SNEEZE

--- a/src/sneeze/network/Encoding.h
+++ b/src/sneeze/network/Encoding.h
@@ -1,0 +1,22 @@
+// Copyright 2026 Metaversal Corporation. All rights reserved.
+
+#ifndef SNEEZE_NETWORK_ENCODING_H
+#define SNEEZE_NETWORK_ENCODING_H
+
+#include <string>
+
+namespace SNEEZE
+{
+   // Promote a string that's either ASCII, valid UTF-8, or ISO-8859-1 into
+   // valid UTF-8. HTTP/1.1 historically allowed ISO-8859-1 in header field
+   // values, and many origins still emit Latin-1 bytes (Server, Date locales,
+   // etc.). Storing the raw bytes in a std::string and later serialising
+   // through nlohmann::json blows up because dump() defaults to strict UTF-8.
+   //
+   // Pure ASCII and already-valid UTF-8 strings pass through unchanged.
+   // Anything else is decoded as Latin-1 and re-encoded as UTF-8, so each
+   // byte 0x80-0xFF becomes its two-byte UTF-8 mapping (0xC2 0x80 - 0xC3 0xBF).
+   std::string ToUtf8 (const std::string& sIn);
+}
+
+#endif // SNEEZE_NETWORK_ENCODING_H

--- a/src/sneeze/network/Network.cpp
+++ b/src/sneeze/network/Network.cpp
@@ -14,6 +14,8 @@
 
 #include <Sneeze.h>
 
+#include "sneeze/network/Encoding.h"
+
 #include <nlohmann/json.hpp>
 #include <openssl/evp.h>
 #include <openssl/sha.h>
@@ -63,7 +65,7 @@ size_t FetchHeaderCallback (char* pData, size_t nSize, size_t nMembers, void* pU
          sValue.clear ();
 
       std::transform (sKey.begin (), sKey.end (), sKey.begin (), ::tolower);
-      (*pmapHeaders)[sKey] = sValue;
+      (*pmapHeaders)[sKey] = SNEEZE::ToUtf8 (sValue);
    }
 
    return nTotal;


### PR DESCRIPTION
## Summary
- HTTP/1.1 historically allows ISO-8859-1 in header field values, and many origins still emit Latin-1 bytes (Server, Date locales, custom fields). The captured headers later end up serialized as JSON in the asset sidecar (`SaveMeta`), and nlohmann::json's `dump()` defaults to strict UTF-8 — one non-UTF-8 byte throws `json.exception.type_error.316` from the fetch worker and aborts the process.
- First seen on Android with a fresh install, where every asset must be re-fetched and the first response from a CDN edge emitting Latin-1 took the whole process down before any rendering could happen. Reproduced on Windows too with a cleared `%APPDATA%\Metaversal\Artemis\` cache — same crash path, just hidden in normal use because the cache survives between runs.
- New `src/sneeze/network/Encoding.{h,cpp}` exposes `SNEEZE::ToUtf8(const std::string&)`. ASCII and already-valid UTF-8 pass through unchanged; anything else is decoded as ISO-8859-1 and re-encoded as UTF-8 (each `0x80–0xFF` byte becomes its two-byte UTF-8 mapping) so the original glyph survives rather than being substituted with U+FFFD.
- `FetchHeaderCallback` runs every captured header value through `ToUtf8` before storing into the headers map.
- The NETWORK fetch-failure warning now includes the curl error code + `curl_easy_strerror` so future fetch failures show the real cause instead of just `HTTP 0`.

## Test plan
- [x] Sneeze CI green across linux / macos / android / ios
- [x] Repro: bug fires on Windows with cleared cache; goes away on a fresh `Artemis.exe` rebuilt against this branch (more fetches succeed; remaining Win32 crash investigation is separate — Latin-1 path is no longer the offender)
- [ ] Artemis-on-Android no longer aborts on first asset fetch after PR #23 lands the CA bundle