### PR TITLE
fix(network): sanitize header keys + try/catch SaveMeta dump

### DIFF
--- a/src/sneeze/network/Network.cpp
+++ b/src/sneeze/network/Network.cpp
@@ -64,8 +64,14 @@ size_t FetchHeaderCallback (char* pData, size_t nSize, size_t nMembers, void* pU
       else
          sValue.clear ();
 
-      std::transform (sKey.begin (), sKey.end (), sKey.begin (), ::tolower);
-      (*pmapHeaders)[sKey] = SNEEZE::ToUtf8 (sValue);
+      // Sanitize both name and value: header names are supposed to be ASCII
+      // per RFC 7230 but some servers cheat. ::tolower on a signed char is UB
+      // for bytes >= 0x80, so cast through unsigned char.
+      sKey   = SNEEZE::ToUtf8 (sKey);
+      sValue = SNEEZE::ToUtf8 (sValue);
+      std::transform (sKey.begin (), sKey.end (), sKey.begin (),
+         [](unsigned char c) { return static_cast<char> (std::tolower (c)); });
+      (*pmapHeaders)[sKey] = sValue;
    }
 
    return nTotal;
@@ -426,7 +432,26 @@ public:
       std::ofstream file (sTmpPath, std::ios::trunc);
       if (file.is_open ())
       {
-         file << jMeta.dump (2);
+         std::string sDump;
+         try
+         {
+            sDump = jMeta.dump (2);
+         }
+         catch (const nlohmann::json::exception& ex)
+         {
+            // The fetch worker thread runs SaveMeta -- letting an exception
+            // escape here aborts the whole process. ToUtf8 in
+            // FetchHeaderCallback should keep this from firing, but if a new
+            // SaveMeta field starts carrying non-UTF-8 we log + drop the
+            // sidecar instead of crashing the app.
+            m_pEngine->Log (IENGINE::kLOGLEVEL_Warning, "NETWORK",
+               "SaveMeta dump failed for " + pAsset->Url () + ": " + ex.what ());
+            file.close ();
+            std::error_code ec;
+            std::filesystem::remove (sTmpPath, ec);
+            return;
+         }
+         file << sDump;
          file.close ();
 
          std::error_code ec;


### PR DESCRIPTION
## Summary
Belt-and-suspenders on top of PR #24 (which only sanitized header VALUES).
- `FetchHeaderCallback` now also runs the header NAME (`sKey`) through `SNEEZE::ToUtf8`. Header names should be ASCII per RFC 7230 but malformed servers can cheat.
- The lowercase pass switched to an explicit `unsigned char` cast — `std::tolower(char)` on a signed char with byte ≥ 0x80 is UB.
- `SaveMeta::dump` wrapped in `try { ... } catch (nlohmann::json::exception&)`: if a future field starts carrying unexpected non-UTF-8 bytes, the worker thread logs + drops the sidecar instead of aborting (`std::terminate` from a worker thread kills the whole process — what we hit on Android in PR #24's setup before the fix).

## Test plan
- [ ] CI green
- [ ] Artemis-on-Android stays up across cleared-cache cold start (same as PR #24 verification)