### PR TITLE
Graceful resize + FetchAsset UAF fix

### DIFF
--- a/src/sneeze/network/Network.cpp
+++ b/src/sneeze/network/Network.cpp
@@ -793,11 +793,12 @@ public:
             NotifyFiles (pAsset->CollectFiles (), STATE_FAILED);
          }
 
-         if (pAsset->GetFileCount () == 0)
+         auto it = m_mapAssets.find (sUrl);
+         if (it != m_mapAssets.end () && it->second.get () == pAsset && pAsset->GetFileCount () == 0)
          {
             if (pAsset->State () == STATE_READY)
                SaveMeta (pAsset);
-            m_mapAssets.erase (sUrl);
+            m_mapAssets.erase (it);
          }
       }
 

--- a/src/viewport/renderer/AnariRenderer.cpp
+++ b/src/viewport/renderer/AnariRenderer.cpp
@@ -83,7 +83,6 @@ RENDERER::ANARI::ANARI (ENGINE* pEngine, const std::string& sLibrary)
    , m_pNativeSurface (nullptr)
    , m_pNativeWindow (nullptr)
    , m_bNativeSurface (false)
-   , m_nResizeGeneration (0)
    , m_nWidth (0)
    , m_nHeight (0)
    , m_bUnitSphereReady (false)
@@ -282,29 +281,8 @@ void RENDERER::ANARI::Resize (int nWidth, int nHeight)
       m_nHeight = nHeight;
       m_aPixels.resize (nWidth * nHeight, 0);
 
-      if (m_pNativeSurface)
-      {
-         ANARIObject ns = reinterpret_cast<ANARIObject> (m_pNativeSurface);
-         ++m_nResizeGeneration;
-         anariSetParameter (m_pDevice, ns, "generation", ANARI_UINT64, &m_nResizeGeneration);
-         anariCommitParameters (m_pDevice, ns);
-      }
-
-      anariRelease (m_pDevice, m_pFrame);
-
-      m_pFrame = anariNewFrame (m_pDevice);
       uint32_t aSize[2] = { static_cast<uint32_t> (nWidth), static_cast<uint32_t> (nHeight) };
       anariSetParameter (m_pDevice, m_pFrame, "size", ANARI_UINT32_VEC2, aSize);
-      ANARIDataType nColorType = ANARI_UFIXED8_RGBA_SRGB;
-      anariSetParameter (m_pDevice, m_pFrame, "channel.color", ANARI_DATA_TYPE, &nColorType);
-      anariSetParameter (m_pDevice, m_pFrame, "renderer", ANARI_RENDERER_TYPE, &m_pRenderer);
-      anariSetParameter (m_pDevice, m_pFrame, "camera", ANARI_CAMERA, &m_pCamera);
-      anariSetParameter (m_pDevice, m_pFrame, "world", ANARI_WORLD, &m_pWorld);
-      if (m_pNativeSurface)
-      {
-         ANARIObject ns = reinterpret_cast<ANARIObject> (m_pNativeSurface);
-         anariSetParameter (m_pDevice, m_pFrame, "nativeSurface", ANARI_OBJECT, &ns);
-      }
       anariCommitParameters (m_pDevice, m_pFrame);
    }
 }

--- a/src/viewport/renderer/AnariRenderer.h
+++ b/src/viewport/renderer/AnariRenderer.h
@@ -77,7 +77,6 @@ namespace SNEEZE
 
       void* m_pNativeWindow;
       bool  m_bNativeSurface;
-      uint64_t m_nResizeGeneration;
 
       int m_nWidth;
       int m_nHeight;


### PR DESCRIPTION
## Summary
- **fix(network)**: re-look up `ASSET` by URL after `NotifyFiles` in `FetchAsset`. Listeners can synchronously drop their last `FILE` handle in `OnFile{Ready,Failed}`, and because the network mutex is recursive the resulting `Release()` runs on the same thread and erases the asset from `m_mapAssets` (freeing the `unique_ptr<ASSET>`). The next `pAsset->GetFileCount()` then dereferenced a freed pImpl — access violation in `std::vector::size`. Re-finding the entry under the lock and only proceeding when it still owns `pAsset` fixes this.
- **feat(viewport)**: drop the destroy-then-create-Frame dance and the `generation` doorbell on `nativeSurface`. On resize Sneeze now just sets `frame.size` and commits, matching the ANARI maintainer's recommended pattern. Halogen's `Frame::commitParameters` now drives the SwapChain rebuild itself when its committed size changes (MetaversalCorp/Halogen#10), so the doorbell is no longer needed.

## Why
The UAF was a pre-existing regression that surfaced under resize because the increased event rate made the OnFileReady → Release → erase → return-to-FetchAsset path race more reliably. The reparameterize change pairs with the Halogen side to give us the graceful resize pattern Jeff recommended without flicker bookkeeping leaking into the embedder.

## Dependencies
- Requires Halogen at master ≥ 52b30d5 (MetaversalCorp/Halogen#10).

## Test plan
- [x] Windows Release: rebuild Sneeze + Artemis after Halogen update; drag-resize Artemis under cdb. No `(cf8.19d0): Access violation` in `ASSET::GetFileCount`, no hang, swapchain rebuilds on resize completion.
- [ ] Linux/macOS/iOS/Android CI builds.
- [ ] Quest build still launches and renders (the only platform that touches `nativeSurface` from real device code besides Win32 desktop).