### PR TITLE
Fix glTF mesh texture V-axis flip

### DIFF
--- a/src/context/viewport/GltfMesh.cpp
+++ b/src/context/viewport/GltfMesh.cpp
@@ -42,6 +42,9 @@ namespace
       return matR;
    }
 
+   // NOTE: out.aTexCoordFlipped must not be reallocated after pfTexCoord pointers
+   // have been borrowed. Both vectors grow in lockstep during Node_Walk and are
+   // never mutated after Gltf_Render_Model_Build returns.
    void Mesh_Emit (GLTF_RENDER_MODEL& out, int nMesh, const MAT4& matWorld)
    {
       const DEP::GLTF_MESH& mesh = out.model.aMesh[nMesh];
@@ -60,7 +63,22 @@ namespace
          if (!prim.aNormal.empty ())
             data.pfNormal = prim.aNormal.data ();
          if (!prim.aTexCoord.empty ())
-            data.pfTexCoord = prim.aTexCoord.data ();
+         {
+            // glTF UV convention: V=0 at top of image.
+            // ANARI/Filament convention: V=0 at bottom of image.
+            // Flip V here at the import edge so every downstream consumer sees
+            // bottom-origin UVs. The flipped buffer is owned by out.aTexCoordFlipped;
+            // data.pfTexCoord borrows from it (same lifetime contract as pfPosition).
+            size_t nUVCount = prim.aTexCoord.size () / 2;
+            out.aTexCoordFlipped.emplace_back (prim.aTexCoord.size ());
+            std::vector<float>& aFlipped = out.aTexCoordFlipped.back ();
+            for (size_t i = 0; i < nUVCount; i++)
+            {
+               aFlipped[i * 2 + 0] =        prim.aTexCoord[i * 2 + 0];
+               aFlipped[i * 2 + 1] = 1.0f - prim.aTexCoord[i * 2 + 1];
+            }
+            data.pfTexCoord = aFlipped.data ();
+         }
          if (!prim.aIndex.empty ())
          {
             data.puIndex     = prim.aIndex.data ();

--- a/src/context/viewport/Viewport.h
+++ b/src/context/viewport/Viewport.h
@@ -99,17 +99,20 @@ namespace SNEEZE
    };
 
    // A loaded glTF model prepared for rendering. Owns all backing storage: the
-   // source CPU model (vertex/index/material data) and the decoded base-color
-   // textures. aMesh is the flattened, renderer-ready draw list -- one MESH_DATA
-   // per primitive, with the node hierarchy baked into each m16 transform. Each
-   // MESH_DATA holds borrowed pointers into model and aTexturePixel, so a
-   // GLTF_RENDER_MODEL must outlive any frame that submits aMesh to the renderer.
+   // source CPU model (vertex/index/material data), the decoded base-color
+   // textures, and the V-flipped UV streams (glTF V=0-at-top -> ANARI V=0-at-bottom).
+   // aMesh is the flattened, renderer-ready draw list -- one MESH_DATA per
+   // primitive, with the node hierarchy baked into each m16 transform. Each
+   // MESH_DATA holds borrowed pointers into model, aTexturePixel, and
+   // aTexCoordFlipped, so a GLTF_RENDER_MODEL must outlive any frame that
+   // submits aMesh to the renderer.
    struct GLTF_RENDER_MODEL
    {
       DEP::GLTF_MODEL                                       model;
       std::vector<std::vector<uint8_t>>                     aTexturePixel;                          // decoded RGBA8, one per source texture
       std::vector<int>                                      aTextureWidth;
       std::vector<int>                                      aTextureHeight;
+      std::vector<std::vector<float>>                       aTexCoordFlipped;                       // V-flipped UV streams, one per emitted primitive
       std::vector<MESH_DATA>                                aMesh;                                  // renderer-ready draw list
       VEC3                                                  vCenter         = { 0.0, 0.0, 0.0 };    // model-space AABB center (post-placement)
       double                                                dRadius         = 0.0;                  // bounding-sphere radius about vCenter

--- a/tests/GltfTest.cpp
+++ b/tests/GltfTest.cpp
@@ -266,6 +266,32 @@ static void TestBuildRenderModel ()
       Check (bAnyTextureDecoded, "At least one base-color texture decoded to RGBA8");
       Check (bAnyTextured, "At least one draw references a decoded texture");
    }
+
+   bool bUvFlipStoragePresent = true;
+   bool bUvValuesInRange      = true;
+   size_t nUvMeshCount = 0;
+   for (const SNEEZE::MESH_DATA& mesh : render.aMesh)
+   {
+      if (mesh.pfTexCoord)
+      {
+         nUvMeshCount++;
+         if (render.aTexCoordFlipped.empty ())
+            bUvFlipStoragePresent = false;
+
+         uint32_t nCheck = std::min (mesh.uCount_Vertex, static_cast<uint32_t> (8));
+         for (uint32_t v = 0; v < nCheck; v++)
+         {
+            float fV = mesh.pfTexCoord[v * 2 + 1];
+            if (fV < 0.0f  ||  fV > 1.0f)
+               bUvValuesInRange = false;
+         }
+      }
+   }
+   if (nUvMeshCount > 0)
+   {
+      Check (bUvFlipStoragePresent, "UV-carrying draws have flipped buffer storage");
+      Check (bUvValuesInRange,      "Flipped V values are in [0, 1]");
+   }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
glTF 2.0 defines UV V=0 at the image top; ANARI/Filament (Halogen) expects V=0 at the bottom. Mesh textures were passed through unflipped, causing vertically mirrored textures on GLB models.

Flip V at the import edge in GltfMesh.cpp (consistent with the Y-up to Z-up coordinate conversion already applied there). Flipped UVs are stored in GLTF_RENDER_MODEL::aTexCoordFlipped; MESH_DATA::pfTexCoord borrows from them.